### PR TITLE
saath/scheduling-assistant

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -658,7 +658,11 @@ paths:
       operationId: PostAPISchedulingFree
       summary: Idempotent route, just returns appropriate time slots along with their respective ratings.
       requestBody:
-        $ref: "#/components/requestBodies/SchedulingSlotsReqBody"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SchedulingSlotsBodySchema"
       responses:
         "200":
           $ref: "#/components/responses/SchedulingSlotsSuccessResponse"
@@ -678,15 +682,6 @@ paths:
                 type: string
 
 components:
-  requestBodies:
-    SchedulingSlotsReqBody:
-      description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)
-      required: true
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/SchedulingSlotsBodySchema"
-
   responses:
     SchedulingSlotsSuccessResponse:
       description: Scheduling algorithm returns the valid time slots and their respective ratings.
@@ -700,6 +695,7 @@ components:
 
   schemas:
     SchedulingSlotsBodySchema:
+      description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)
       type: object
       properties:
         attendees:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -686,10 +686,78 @@ paths:
                 type: string
 
 components:
+  requestBodies:
+    SchedulingSlotsBody:
+      description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              attendees:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AttendeeBase"
+              meetingDuration:
+                type: string
+                description: >
+                  The length of the meeting, denoted in **ISO 8601** format.  
+                  - Example:  
+                    - **1 hour** → `'PT1H'`
+                    - **2 hours, 30 minutes** → `'PT2H30M'`
+                  - `'P'` is the duration designator.
+                  - `'T'` separates date and time components.
+                  - `'H'` (hours) and `'M'` (minutes) specify the time duration.
+                  - If omitted, the default duration is **30 minutes** (`'PT30M'`).
+                example: "PT2H30M"
+              isOrganizerOptional:
+                type: boolean
+              maxCandidates:
+                type: integer
+                format: uint32
+
+            required:
+              - attendees
+              - isOrganizerOptional
+
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid
+
   schemas:
+    AttendeeType:
+      type: string
+      enum:
+        - required
+        - optional
+        - resource
+
+    EmailAddress:
+      type: object
+      description: directly maps to MSFT Email Address, see info here:[MSFT EmailAddress Struct Docs](https://learn.microsoft.com/en-us/graph/api/resources/emailaddress?view=graph-rest-1.0)
+      properties:
+        address:
+          type: string
+          format: email
+        name:
+          type: string
+      required:
+        - address
+        - name
+
+    AttendeeBase:
+      type: object
+      description: directly maps to MSFT attendeeBase, see info here:[MSFT attendeeBase Struct Docs](https://learn.microsoft.com/en-us/graph/api/resources/attendeebase?view=graph-rest-1.0)
+      properties:
+        emailAddress:
+          $ref: "#/components/schemas/EmailAddress"
+        attendeeType:
+          $ref: "#/components/schemas/AttendeeType"
+      required:
+        - emailAddress
+        - attendeeType
+
     # Microsoft Attendee
     # see: https://learn.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0#properties
     Attendee:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -694,6 +694,19 @@ components:
       description: Access token is missing or invalid
 
   schemas:
+    TimeConstraint:
+      description: Maps directly to [MSFT timeConstraint](https://learn.microsoft.com/en-us/graph/api/resources/timeconstraint?view=graph-rest-1.0)
+      type: object
+      properties:
+        activityDomain:
+          type: string
+        timeSlots:
+          type: array
+          items:
+            $ref: "#/components/schemas/MeetingTimeSlot"
+      required:
+        - timeSlots
+
     SchedulingSlotsBodySchema:
       description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)
       type: object
@@ -726,7 +739,9 @@ components:
           format: double
         maxCandidates:
           type: integer
-          format: uint32
+          format: int32
+        timeConstraint:
+          $ref: "#/components/schemas/TimeConstraint"
 
       required:
         - attendees
@@ -734,6 +749,7 @@ components:
         - locationConstraint
         - meetingDuration
         - meetingName
+        - timeConstraint
 
     PhysicalAddress:
       description: Maps directly to [MSFT physicalAddress](https://learn.microsoft.com/en-us/graph/api/resources/locationconstraintitem?view=graph-rest-1.0)
@@ -826,6 +842,9 @@ components:
         start:
           type: string
           format: date-time
+      required:
+        - end
+        - start
 
     MeetingTimeSuggestion:
       description: Maps roughly to [MSFT meetingTimeSuggestion](https://learn.microsoft.com/en-us/graph/api/resources/meetingtimesuggestion?view=graph-rest-1.0)

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -656,20 +656,12 @@ paths:
   /api/scheduling/slots:
     post:
       operationId: PostAPISchedulingFree
-      summary: Doesn't create anything, just returns appropriate time slots along with their respective ratings.
+      summary: Idempotent route, just returns appropriate time slots along with their respective ratings.
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SchedulingBody"
+        $ref: "#/components/requestBodies/SchedulingSlotsBody"
       responses:
         "200":
-          description: Scheduling algorithm returns the valid time slots and their respective ratings.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SchedulingResponse"
+          $ref: "#/components/responses/SchedulingSlotsSuccessResponse"
         "400":
           description: Bad request (e.g., invalid event data)
           content:
@@ -687,6 +679,8 @@ paths:
 
 components:
   requestBodies:
+    # TODO: Add location constraint
+    # should we include minimumAttendeePercentage?
     SchedulingSlotsBody:
       description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)
       required: true
@@ -722,11 +716,98 @@ components:
               - isOrganizerOptional
 
   responses:
+    SchedulingSlotsSuccessResponse:
+      description: Scheduling algorithm returns the valid time slots and their respective ratings.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SchedulingSlotsSuccessResponseBody"
+
     UnauthorizedError:
       description: Access token is missing or invalid
 
   schemas:
+    EmptySuggestionsReason:
+      description: Maps directly to [MSFT emptySuggestionsReason](https://learn.microsoft.com/en-us/graph/api/resources/meetingtimesuggestionsresult?view=graph-rest-1.0)
+      type: string
+      enum:
+        - attendeesUnavailable
+        - attendeesUnavailableOrUnknown
+        - locationsUnavailable
+        - organizerUnavailable
+        - unknown
+
+    FreeBusyStatus:
+      description: Maps directly to [MSFT freebusyStatus](https://learn.microsoft.com/en-us/graph/api/resources/attendeeavailability?view=graph-rest-1.0)
+      type: string
+      enum:
+        - free
+        - tentative
+        - busy
+        - oof
+        - workingElsewhere
+        - unknown
+
+    AttendeeAvailability:
+      description: Maps roughly to [MSFT attendeeAvailability](https://learn.microsoft.com/en-us/graph/api/resources/attendeeavailability?view=graph-rest-1.0)
+      properties:
+        availability:
+          $ref: "#/components/schemas/FreeBusyStatus"
+        attendee:
+          $ref: "#/components/schemas/AttendeeBase"
+      required:
+        - availability
+        - attendee
+
+    MeetingTimeSlot:
+      description: Maps directly to [MSFT meetingTimeSlot](https://learn.microsoft.com/en-us/graph/api/resources/timeslot?view=graph-rest-1.0)
+      type: object
+      properties:
+        end:
+          type: string
+          format: date-time
+        start:
+          type: string
+          format: date-time
+
+    MeetingTimeSuggestion:
+      description: Maps roughly to [MSFT meetingTimeSuggestion](https://learn.microsoft.com/en-us/graph/api/resources/meetingtimesuggestion?view=graph-rest-1.0)
+      type: object
+      properties:
+        attendeeAvailability:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttendeeAvailability"
+        confidence:
+          type: number
+          format: double
+        locations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Location"
+        meetingTimeSlot:
+          $ref: "#/components/schemas/MeetingTimeSlot"
+        order:
+          type: integer
+          format: int32
+        organizerAvailability:
+          type: string
+        suggestionReason:
+          type: string
+
+    SchedulingSlotsSuccessResponseBody:
+      description: Maps roughly to [MSFT meetingTimeSuggestionsResult](https://learn.microsoft.com/en-us/graph/api/resources/meetingtimesuggestionsresult?view=graph-rest-1.0)
+      type: object
+      properties:
+        emptySuggestionsReason:
+          $ref: "#/components/schemas/EmptySuggestionsReason"
+        meetingTimeSuggestions:
+          type: array
+          items:
+            $ref: "#/components/schemas/MeetingTimeSuggestion"
+
     AttendeeType:
+      description: Maps directly to [MSFT Attendee->type](https://learn.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0)
       type: string
       enum:
         - required
@@ -769,9 +850,8 @@ components:
           format: email
           nullable: true
         # Attendee -> type
-        type:
-          type: string
-          enum: [required, optional, resource]
+        attendeeType:
+          $ref: "#/components/schemas/AttendeeType"
           nullable: true
         # Attendee -> status
         responseStatus:
@@ -838,8 +918,9 @@ components:
         - locations
 
     # Microsoft Location
-    # See: https://learn.microsoft.com/en-us/graph/api/resources/location?view=graph-rest-1.0
+    # See:
     Location:
+      description: Maps roughly to [MSFT Location](https://learn.microsoft.com/en-us/graph/api/resources/location?view=graph-rest-1.0)
       type: object
       properties:
         # non nullable

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -658,7 +658,7 @@ paths:
       operationId: PostAPISchedulingFree
       summary: Idempotent route, just returns appropriate time slots along with their respective ratings.
       requestBody:
-        $ref: "#/components/requestBodies/SchedulingSlotsBody"
+        $ref: "#/components/requestBodies/SchedulingSlotsReqBody"
       responses:
         "200":
           $ref: "#/components/responses/SchedulingSlotsSuccessResponse"
@@ -679,41 +679,13 @@ paths:
 
 components:
   requestBodies:
-    # TODO: Add location constraint
-    # should we include minimumAttendeePercentage?
-    SchedulingSlotsBody:
+    SchedulingSlotsReqBody:
       description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)
       required: true
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              attendees:
-                type: array
-                items:
-                  $ref: "#/components/schemas/AttendeeBase"
-              meetingDuration:
-                type: string
-                description: >
-                  The length of the meeting, denoted in **ISO 8601** format.  
-                  - Example:  
-                    - **1 hour** → `'PT1H'`
-                    - **2 hours, 30 minutes** → `'PT2H30M'`
-                  - `'P'` is the duration designator.
-                  - `'T'` separates date and time components.
-                  - `'H'` (hours) and `'M'` (minutes) specify the time duration.
-                  - If omitted, the default duration is **30 minutes** (`'PT30M'`).
-                example: "PT2H30M"
-              isOrganizerOptional:
-                type: boolean
-              maxCandidates:
-                type: integer
-                format: uint32
-
-            required:
-              - attendees
-              - isOrganizerOptional
+            $ref: "#/components/schemas/SchedulingSlotsBodySchema"
 
   responses:
     SchedulingSlotsSuccessResponse:
@@ -727,6 +699,95 @@ components:
       description: Access token is missing or invalid
 
   schemas:
+    SchedulingSlotsBodySchema:
+      type: object
+      properties:
+        attendees:
+          type: array
+          items:
+            $ref: "#/components/schemas/AttendeeBase"
+        meetingName:
+          description: custom field, this is used for the AI model
+          type: string
+        meetingDuration:
+          type: string
+          description: >
+            The length of the meeting, denoted in **ISO 8601** format.
+            - Example:
+              - **1 hour** → `'PT1H'`
+              - **2 hours, 30 minutes** → `'PT2H30M'`
+            - `'P'` is the duration designator.
+            - `'T'` separates date and time components.
+            - `'H'` (hours) and `'M'` (minutes) specify the time duration.
+            - If omitted, the default duration is **30 minutes** (`'PT30M'`).
+          example: "PT2H30M"
+        isOrganizerOptional:
+          type: boolean
+        locationConstraint:
+          $ref: "#/components/schemas/LocationConstraint"
+        minimumAttendeePercentage:
+          type: number
+          format: double
+        maxCandidates:
+          type: integer
+          format: uint32
+
+      required:
+        - attendees
+        - isOrganizerOptional
+        - locationConstraint
+        - meetingDuration
+        - meetingName
+
+    PhysicalAddress:
+      description: Maps directly to [MSFT physicalAddress](https://learn.microsoft.com/en-us/graph/api/resources/locationconstraintitem?view=graph-rest-1.0)
+      properties:
+        city:
+          type: string
+          description: The city.
+        countryOrRegion:
+          type: string
+          description: The country or region. It's a free-format string value, for example, "United States".
+        postalCode:
+          type: string
+          description: The postal code.
+        state:
+          type: string
+          description: The state.
+        street:
+          type: string
+          description: The street.
+
+    LocationConstraintItem:
+      description: Maps roughly to [MSFT locationConstraintItem](https://learn.microsoft.com/en-us/graph/api/resources/locationconstraintitem?view=graph-rest-1.0)
+      type: object
+      properties:
+        displayName:
+          type: string
+        resolveAvailability:
+          type: boolean
+        locationEmailAddress:
+          type: string
+        address:
+          $ref: "#/components/schemas/PhysicalAddress"
+      required:
+        - displayName
+        - resolveAvailability
+        - address
+
+    LocationConstraint:
+      description: Maps directly to [MSFT locationConstraint](https://learn.microsoft.com/en-us/graph/api/resources/locationconstraint?view=graph-rest-1.0)
+      type: object
+      properties:
+        isRequired:
+          type: boolean
+        locations:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocationConstraintItem"
+        suggestLocation:
+          type: boolean
+
     EmptySuggestionsReason:
       description: Maps directly to [MSFT emptySuggestionsReason](https://learn.microsoft.com/en-us/graph/api/resources/meetingtimesuggestionsresult?view=graph-rest-1.0)
       type: string
@@ -829,7 +890,7 @@ components:
 
     AttendeeBase:
       type: object
-      description: directly maps to MSFT attendeeBase, see info here:[MSFT attendeeBase Struct Docs](https://learn.microsoft.com/en-us/graph/api/resources/attendeebase?view=graph-rest-1.0)
+      description: directly maps to [MSFT attendeeBase](https://learn.microsoft.com/en-us/graph/api/resources/attendeebase?view=graph-rest-1.0)
       properties:
         emailAddress:
           $ref: "#/components/schemas/EmailAddress"
@@ -839,9 +900,8 @@ components:
         - emailAddress
         - attendeeType
 
-    # Microsoft Attendee
-    # see: https://learn.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0#properties
     Attendee:
+      description: Maps roughly to [MSFT Attendee](https://learn.microsoft.com/en-us/graph/api/resources/attendee?view=graph-rest-1.0#properties)
       type: object
       properties:
         # Attendee -> emailAddress
@@ -867,9 +927,8 @@ components:
             ]
           nullable: true
 
-    # Microsoft Calendar Event
-    # see: https://learn.microsoft.com/en-us/graph/api/resources/responsestatus?view=graph-rest-1.0#properties
     CalendarEvent:
+      description: Maps roughly to [MSFT event](https://learn.microsoft.com/en-us/graph/api/resources/event?view=graph-rest-1.0#properties)
       type: object
       properties:
         id:
@@ -891,17 +950,16 @@ components:
           nullable: true
         isCancelled:
           type: boolean
-        # OPTIONAL custom field: OnlineMeetingInfo->joinURL
-        # see: https://learn.microsoft.com/en-us/graph/api/resources/onlinemeetinginfo?view=graph-rest-1.0#json-representation
         joinURL:
+          description: Maps roughly to [MSFT OnlineMeetingInfo->joinURL](https://learn.microsoft.com/en-us/graph/api/resources/onlinemeetinginfo?view=graph-rest-1.0#json-representation)
           type: string
           nullable: true
         locations:
           type: array
           items:
             $ref: "#/components/schemas/Location"
-        # custom field: Recipient -> emailAddress
         organizer:
+          description: Maps roughly to [MSFT Recipient->emailAddress](https://learn.microsoft.com/en-us/graph/api/resources/recipient?view=graph-rest-1.0)
           type: string
           format: email
         # custom field: start
@@ -917,8 +975,6 @@ components:
         - attendees
         - locations
 
-    # Microsoft Location
-    # See:
     Location:
       description: Maps roughly to [MSFT Location](https://learn.microsoft.com/en-us/graph/api/resources/location?view=graph-rest-1.0)
       type: object
@@ -1019,62 +1075,3 @@ components:
       required:
         - id
         - name
-
-    SchedulingBody:
-      type: object
-      properties:
-        startDate:
-          type: string
-          format: date-time
-        endDate:
-          type: string
-          format: date-time
-        eventName:
-          type: string
-        eventDuration:
-          type: integer
-          format: uint32
-        participants:
-          type: array
-          items:
-            type: string
-            format: email
-        location:
-          $ref: "#/components/schemas/Location"
-      required:
-        - startDate
-        - endDate
-        - eventName
-        - eventDuration
-        - participants
-
-    SchedulingResponse:
-      type: array
-      items:
-        type: object
-        properties:
-          date:
-            type: string
-            format: date-time
-          startTime:
-            type: string
-            format: date-time
-          endTime:
-            type: string
-            format: date-time
-          overallRating:
-            type: number
-            format: float
-          reschedulingRequired:
-            type: boolean
-          ratingDistribution:
-            type: array
-            items:
-              type: object
-              properties:
-                userID:
-                  type: integer
-                  format: uint32
-                rating:
-                  type: number
-                  format: float


### PR DESCRIPTION
- Change the request and response body of the `/api/scheduling/slots` route to make it easier to use the [findMeetings endpoint](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http) 
- Add other common MSFT enums and schemas