### PR TITLE
Jnile/single reschedule endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -811,14 +811,13 @@ paths:
               schema:
                 type: string
 
-  /api/reschedule/request:
+  /api/reschedule/requests/me:
     get:
-      operationId: GetAPIRescheduleRequest
+      operationId: GetAPIRescheduleRequestsMe
       summary: Get all reschedule requests for current user.
       responses:
         "200":
           $ref: "#/components/responses/RescheduleRequests"
-        
         "400":
           description: Bad request (e.g., invalid event data)
           content:
@@ -837,7 +836,7 @@ paths:
   /api/reschedule/request/{requestID}:
     get:
       operationId: GetAPIRescheduleRequestRequestID
-      summary: Get all reschedule requests for current user.
+      summary: Get all reschedule requests by request id.
       parameters:
         - in: path
           name: requestID
@@ -853,7 +852,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RescheduleRequest"
-        
+
         "400":
           description: Bad request (e.g., invalid event data)
           content:
@@ -872,7 +871,7 @@ paths:
   /api/reschedule/request/{requestID}/reject:
     patch:
       operationId: PatchAPIRescheduleRequestRequestIDReject
-      summary: Reject a reschedule request
+      summary: Reject a reschedule request by id.
       parameters:
         - in: path
           name: requestID
@@ -896,11 +895,11 @@ paths:
           description: Invite not found
         "500":
           description: Something went wrong internally
-  
+
   /api/reschedule/request/{requestID}/accept:
     patch:
       operationId: PatchAPIRescheduleRequestRequestIDAccept
-      summary: Accept a reschedule request
+      summary: Accept a reschedule request by request id.
       parameters:
         - in: path
           name: requestID
@@ -935,14 +934,13 @@ paths:
   /api/reschedule/request/replace:
     post:
       operationId: PostAPIRescheduleRequestReplace
-      summary: Request to reschedule the old meeting for a new meeting
+      summary: Create a request to reschedule the old meeting for a new meeting.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/ReschedulingRequestBodySchema"
-
       responses:
         "200":
           description: Successfully requested to reschedule the old meeting
@@ -1184,7 +1182,6 @@ components:
             items:
               $ref: "#/components/schemas/RescheduleRequest"
 
-
     UnauthorizedError:
       description: Access token is missing or invalid
 
@@ -1212,7 +1209,7 @@ components:
         - requested_at
         - oldMeeting
       properties:
-        request_id: 
+        request_id:
           type: integer
           format: uint32
           description: The request ID
@@ -1231,7 +1228,7 @@ components:
           $ref: "#/components/schemas/ReschedulingRequestOldMeeting"
         newMeeting:
           $ref: "#/components/schemas/ReschedulingRequestNewMeeting"
-    
+
     ReschedulingRequestAcceptBodySchema:
       type: object
       required:
@@ -1242,18 +1239,18 @@ components:
           type: string
           format: date-time
           description: >
-                The start of the meeting denoted in *ISO 8601* format
-                In the format: yyyy-mm-ddThh:mm:ssZ
-                Where lowercase letters are replaced by their numerical values
+            The start of the meeting denoted in *ISO 8601* format
+            In the format: yyyy-mm-ddThh:mm:ssZ
+            Where lowercase letters are replaced by their numerical values
 
         newEndTime:
           type: string
           format: date-time
           description: >
-                The start of the meeting denoted in *ISO 8601* format
-                In the format: yyyy-mm-ddThh:mm:ssZ
-                Where lowercase letters are replaced by their numerical values
-        
+            The start of the meeting denoted in *ISO 8601* format
+            In the format: yyyy-mm-ddThh:mm:ssZ
+            Where lowercase letters are replaced by their numerical values
+
     ReschedulingRequestOldMeeting:
       type: object
       required:
@@ -1267,7 +1264,7 @@ components:
           type: integer
           format: uint32
           description: The meeting ID of the old meeting
-    
+
     ReschedulingRequestNewMeeting:
       type: object
       required:
@@ -1309,7 +1306,6 @@ components:
         location:
           type: string
           description: The location of the meeting
-
 
     ReschedulingCheckBodySchema:
       description: Request body of the details of the two meetings

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1228,20 +1228,21 @@ components:
     ReschedulingRequestAcceptBodySchema:
       type: object
       properties:
-        msftMeetingID:
-          type: string
-          description: The microsoft meeting ID of the new meeting
-        meetingId:
-          type: integer
-          description: The meeting ID of the new meeting
         newStartTime:
           type: string
           format: date-time
-          description: The start of the new meeting denoted in *ISO 8601* format
+          description: >
+                The start of the meeting denoted in *ISO 8601* format
+                In the format: yyyy-mm-ddThh:mm:ssZ
+                Where lowercase letters are replaced by their numerical values
+
         newEndTime:
           type: string
           format: date-time
-          description: The end of the new meeting denoted in *ISO 8601* format
+          description: >
+                The start of the meeting denoted in *ISO 8601* format
+                In the format: yyyy-mm-ddThh:mm:ssZ
+                Where lowercase letters are replaced by their numerical values
         
     ReschedulingRequestOldMeeting:
       type: object
@@ -1274,11 +1275,17 @@ components:
         startTime:
           type: string
           format: date-time
-          description: The start of the meeting denoted in *ISO 8601* format
+          description: >
+            The start of the meeting denoted in *ISO 8601* format
+            In the format: yyyy-mm-ddThh:mm:ssZ
+            Where lowercase letters are replaced by their numerical values
         endTime:
           type: string
           format: date-time
-          description: The end of the meeting denoted in *ISO 8601* format
+          description: >
+            The start of the meeting denoted in *ISO 8601* format
+            In the format: yyyy-mm-ddThh:mm:ssZ
+            Where lowercase letters are replaced by their numerical values
         location:
           type: string
           description: The location of the meeting
@@ -1315,37 +1322,13 @@ components:
         oldMeeting:
           type: object
           properties:
-            meetingID:
-              type: integer
-              description: The meeting ID of the old meeting if it exists
-            title:
+            msftMeetingID:
               type: string
-              description: name of the meeting
-            meetingDuration:
-              type: string
-              description: >
-                The length of the meeting, denoted in **ISO 8601** format.
-                - Example:
-                  - **1 hour** → `'PT1H'`
-                  - **2 hours, 30 minutes** → `'PT2H30M'`
-                - `'P'` is the duration designator.
-                - `'T'` separates date and time components.
-                - `'H'` (hours) and `'M'` (minutes) specify the time duration.
-                - If omitted, the default duration is **30 minutes** (`'PT30M'`).
-              example: "PT2H30M"
-            attendees:
-              type: array
-              items:
-                $ref: "#/components/schemas/AttendeeBase"
-              description: Array of all the attendees
+              description: The microsoft meeting ID of the old meeting if it exists
             isOrganizerOptional:
               type: boolean
-            locationConstraint:
-              $ref: "#/components/schemas/LocationConstraint"
-            startTime:
-              type: string
-              format: date-time
-              description: The start of the meeting denoted in *ISO 8601* format
+              default: false
+              description: if organizer does not need to be there, then set true. If the organizer is the only person in the meeting, keep false
 
     ReschedulingRequestBodySchema:
       description: Request body of the details of the two meetings
@@ -1378,22 +1361,34 @@ components:
             startTime:
               type: string
               format: date-time
-              description: The start of the meeting denoted in *ISO 8601* format
+              description: >
+                The start of the meeting denoted in *ISO 8601* format
+                In the format: yyyy-mm-ddThh:mm:ssZ
+                Where lowercase letters are replaced by their numerical values
             endTime:
               type: string
               format: date-time
-              description: The end of the meeting denoted in *ISO 8601* format
+              description: >
+                The start of the meeting denoted in *ISO 8601* format
+                In the format: yyyy-mm-ddThh:mm:ssZ
+                Where lowercase letters are replaced by their numerical values
             location:
               type: string
               description: The location of the meeting
             startRangeTime:
               type: string
               format: date-time
-              description: The start of the range of the meeting denoted in *ISO 8601* format
+              description: >
+                The start of the meeting denoted in *ISO 8601* format
+                In the format: yyyy-mm-ddThh:mm:ssZ
+                Where lowercase letters are replaced by their numerical values
             endRangeTime:
               type: string
               format: date-time
-              description: The end of the range of the meeting denoted in *ISO 8601* format
+              description: >
+                The start of the meeting denoted in *ISO 8601* format
+                In the format: yyyy-mm-ddThh:mm:ssZ
+                Where lowercase letters are replaced by their numerical values
 
         oldMeeting:
           type: object
@@ -1413,19 +1408,9 @@ components:
       description: Request body of the details of the old meeting
       type: object
       properties:
-        oldMeeting:
-          type: object
-          properties:
-            msftMeetingID:
-              type: string
-              description: The microsoft meeting ID of the old meeting
-            meetingStartTime:
-              type: string
-              format: date-time
-              description: The start of the meeting denoted in *ISO 8601* format
-            meetingOwner:
-              type: integer
-              description: Meeting owner ID
+        msftMeetingID:
+          type: string
+          description: The microsoft meeting ID of the old meeting
 
     SchedulingSlotsBodySchema:
       description: Roughly maps to [MSFT Find Meeting Schema](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0&tabs=http#request-body)

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -814,13 +814,46 @@ paths:
   /api/reschedule/request/replace:
     post:
       operationId: PostAPIRescheduleRequestReplace
-      summary: Request to reschedule the old meeting
+      summary: Request to reschedule the old meeting for a new meeting
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/ReschedulingRequestBodySchema"
+
+      responses:
+        "200":
+          description: Successfully requested to reschedule the old meeting
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Bad request (e.g., invalid event data)
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          description: Something went wrong internally
+          content:
+            application/json:
+              schema:
+                type: string
+
+  /api/reschedule/request/single:
+    post:
+      operationId: PostAPIRescheduleRequestSingle
+      summary: Request to reschedule the old meeting by itself
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReschedulingRequestSingleBodySchema"
 
       responses:
         "200":
@@ -1152,7 +1185,25 @@ components:
         oldMeeting:
           type: object
           properties:
-            meetingID:
+            msftMeetingID:
+              type: string
+              description: The microsoft meeting ID of the old meeting
+            meetingStartTime:
+              type: string
+              format: date-time
+              description: The start of the meeting denoted in *ISO 8601* format
+            meetingOwner:
+              type: integer
+              description: Meeting owner ID
+
+    ReschedulingRequestSingleBodySchema:
+      description: Request body of the details of the old meeting
+      type: object
+      properties:
+        oldMeeting:
+          type: object
+          properties:
+            msftMeetingID:
               type: string
               description: The microsoft meeting ID of the old meeting
             meetingStartTime:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -834,6 +834,41 @@ paths:
               schema:
                 type: string
 
+  /api/reschedule/request/{requestID}:
+    get:
+      operationId: GetAPIRescheduleRequestRequestID
+      summary: Get all reschedule requests for current user.
+      parameters:
+        - in: path
+          name: requestID
+          schema:
+            type: integer
+            format: uint32
+          required: true
+          description: Numeric ID of the reschedule request to get
+      responses:
+        "200":
+          description: Successfully get the reschedule request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RescheduleRequest"
+        
+        "400":
+          description: Bad request (e.g., invalid event data)
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          description: Something went wrong internally
+          content:
+            application/json:
+              schema:
+                type: string
+
   /api/reschedule/request/replace:
     post:
       operationId: PostAPIRescheduleRequestReplace

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -896,6 +896,41 @@ paths:
           description: Invite not found
         "500":
           description: Something went wrong internally
+  
+  /api/reschedule/request/{requestID}/accept:
+    patch:
+      operationId: PatchAPIRescheduleRequestRequestIDAccept
+      summary: Accept a reschedule request
+      parameters:
+        - in: path
+          name: requestID
+          schema:
+            type: integer
+            format: uint32
+          required: true
+          description: Numeric ID of the reschedule request to get
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReschedulingRequestAcceptBodySchema"
+
+      responses:
+        "201":
+          description: Successfully accepted the rescheduling request.
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Bad request
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          description: Invite not found
+        "500":
+          description: Something went wrong internally
 
 
   /api/reschedule/request/replace:
@@ -1190,6 +1225,24 @@ components:
         newMeeting:
           $ref: "#/components/schemas/ReschedulingRequestNewMeeting"
     
+    ReschedulingRequestAcceptBodySchema:
+      type: object
+      properties:
+        msftMeetingID:
+          type: string
+          description: The microsoft meeting ID of the new meeting
+        meetingId:
+          type: integer
+          description: The meeting ID of the new meeting
+        newStartTime:
+          type: string
+          format: date-time
+          description: The start of the new meeting denoted in *ISO 8601* format
+        newEndTime:
+          type: string
+          format: date-time
+          description: The end of the new meeting denoted in *ISO 8601* format
+        
     ReschedulingRequestOldMeeting:
       type: object
       properties:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -869,10 +869,10 @@ paths:
               schema:
                 type: string
 
-  /api/reschedule/request/{requestID}/decline:
+  /api/reschedule/request/{requestID}/reject:
     patch:
-      operationId: PatchAPIRescheduleRequestRequestIDDecline
-      summary: Decline a reschedule request
+      operationId: PatchAPIRescheduleRequestRequestIDReject
+      summary: Reject a reschedule request
       parameters:
         - in: path
           name: requestID
@@ -883,7 +883,7 @@ paths:
           description: Numeric ID of the reschedule request to get
       responses:
         "201":
-          description: Successfully declined rescheduling request.
+          description: Successfully rejected the rescheduling request.
           content:
             application/json:
               schema:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -811,6 +811,29 @@ paths:
               schema:
                 type: string
 
+  /api/reschedule/request:
+    get:
+      operationId: GetAPIRescheduleRequest
+      summary: Get all reschedule requests for current user.
+      responses:
+        "200":
+          $ref: "#/components/responses/RescheduleRequests"
+        
+        "400":
+          description: Bad request (e.g., invalid event data)
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          description: Something went wrong internally
+          content:
+            application/json:
+              schema:
+                type: string
+
   /api/reschedule/request/replace:
     post:
       operationId: PostAPIRescheduleRequestReplace
@@ -1054,6 +1077,16 @@ components:
           schema:
             $ref: "#/components/schemas/SchedulingSlotsSuccessResponseBody"
 
+    RescheduleRequests:
+      description: All the reschedule requests for the current user
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/RescheduleRequest"
+
+
     UnauthorizedError:
       description: Access token is missing or invalid
 
@@ -1070,6 +1103,69 @@ components:
             $ref: "#/components/schemas/MeetingTimeSlot"
       required:
         - timeSlots
+
+    RescheduleRequest:
+      description: Reschedule request object
+      type: object
+      properties:
+        request_id: 
+          type: integer
+          description: The request ID
+        requested_by:
+          type: integer
+          description: The user ID of the person who requested the reschedule
+        status:
+          type: string
+          description: The status of the reschedule request
+        requested_at:
+          type: string
+          format: date-time
+          description: The time the request was made
+        oldMeeting:
+          $ref: "#/components/schemas/ReschedulingRequestOldMeeting"
+        newMeeting:
+          $ref: "#/components/schemas/ReschedulingRequestNewMeeting"
+    
+    ReschedulingRequestOldMeeting:
+      type: object
+      properties:
+        msftMeetingID:
+          type: string
+          description: The microsoft meeting ID of the old meeting
+        meetingId:
+          type: integer
+          description: The meeting ID of the old meeting
+    
+    ReschedulingRequestNewMeeting:
+      type: object
+      properties:
+        title:
+          type: string
+          description: name of the meeting
+        meetingDuration:
+          type: string
+          description: >
+            The length of the meeting, denoted in **ISO 8601** format.
+            - Example:
+              - **1 hour** → `'PT1H'`
+              - **2 hours, 30 minutes** → `'PT2H30M'`
+            - `'P'` is the duration designator.
+            - `'T'` separates date and time components.
+            - `'H'` (hours) and `'M'` (minutes) specify the time duration.
+            - If omitted, the default duration is **30 minutes** (`'PT30M'`).
+          example: "PT2H30M"
+        startTime:
+          type: string
+          format: date-time
+          description: The start of the meeting denoted in *ISO 8601* format
+        endTime:
+          type: string
+          format: date-time
+          description: The end of the meeting denoted in *ISO 8601* format
+        location:
+          type: string
+          description: The location of the meeting
+
 
     ReschedulingCheckBodySchema:
       description: Request body of the details of the two meetings

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -869,6 +869,35 @@ paths:
               schema:
                 type: string
 
+  /api/reschedule/request/{requestID}/decline:
+    patch:
+      operationId: PatchAPIRescheduleRequestRequestIDDecline
+      summary: Decline a reschedule request
+      parameters:
+        - in: path
+          name: requestID
+          schema:
+            type: integer
+            format: uint32
+          required: true
+          description: Numeric ID of the reschedule request to get
+      responses:
+        "201":
+          description: Successfully declined rescheduling request.
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Bad request
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          description: Invite not found
+        "500":
+          description: Something went wrong internally
+
+
   /api/reschedule/request/replace:
     post:
       operationId: PostAPIRescheduleRequestReplace

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -932,7 +932,6 @@ paths:
         "500":
           description: Something went wrong internally
 
-
   /api/reschedule/request/replace:
     post:
       operationId: PostAPIRescheduleRequestReplace
@@ -1206,12 +1205,20 @@ components:
     RescheduleRequest:
       description: Reschedule request object
       type: object
+      required:
+        - request_id
+        - requested_by
+        - status
+        - requested_at
+        - oldMeeting
       properties:
         request_id: 
           type: integer
+          format: uint32
           description: The request ID
         requested_by:
           type: integer
+          format: uint32
           description: The user ID of the person who requested the reschedule
         status:
           type: string
@@ -1227,6 +1234,9 @@ components:
     
     ReschedulingRequestAcceptBodySchema:
       type: object
+      required:
+        - newStartTime
+        - newEndTime
       properties:
         newStartTime:
           type: string
@@ -1246,16 +1256,26 @@ components:
         
     ReschedulingRequestOldMeeting:
       type: object
+      required:
+        - msftMeetingID
+        - meetingId
       properties:
         msftMeetingID:
           type: string
           description: The microsoft meeting ID of the old meeting
         meetingId:
           type: integer
+          format: uint32
           description: The meeting ID of the old meeting
     
     ReschedulingRequestNewMeeting:
       type: object
+      required:
+        - title
+        - meetingDuration
+        - startTime
+        - endTime
+        - location
       properties:
         title:
           type: string
@@ -1294,9 +1314,16 @@ components:
     ReschedulingCheckBodySchema:
       description: Request body of the details of the two meetings
       type: object
+      required:
+        - newMeeting
+        - oldMeeting
       properties:
         newMeeting:
           type: object
+          required:
+            - title
+            - meetingDuration
+            - attendees
           properties:
             title:
               type: string
@@ -1321,6 +1348,8 @@ components:
 
         oldMeeting:
           type: object
+          required:
+            - msftMeetingID
           properties:
             msftMeetingID:
               type: string
@@ -1333,9 +1362,21 @@ components:
     ReschedulingRequestBodySchema:
       description: Request body of the details of the two meetings
       type: object
+      required:
+        - newMeeting
+        - oldMeeting
       properties:
         newMeeting:
           type: object
+          required:
+            - title
+            - meetingDuration
+            - attendees
+            - startTime
+            - endTime
+            - location
+            - startRangeTime
+            - endRangeTime
           properties:
             title:
               type: string
@@ -1392,6 +1433,10 @@ components:
 
         oldMeeting:
           type: object
+          required:
+            - msftMeetingID
+            - meetingStartTime
+            - meetingOwner
           properties:
             msftMeetingID:
               type: string
@@ -1407,6 +1452,8 @@ components:
     ReschedulingRequestSingleBodySchema:
       description: Request body of the details of the old meeting
       type: object
+      required:
+        - msftMeetingID
       properties:
         msftMeetingID:
           type: string

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -139,7 +139,7 @@ DROP TABLE IF EXISTS Meeting;
 CREATE TABLE Meeting (
 	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
 	meeting_pref_id INT UNSIGNED NOT NULL,
-	owner_id INT UNSIGNED NOT NULL,
+	owner_email VARCHAR(255) NOT NULL,
 	msft_meeting_id TEXT NOT NULL,
 	CONSTRAINT fk_Meeting_MeetingPreferences FOREIGN KEY (meeting_pref_id) REFERENCES MeetingPreferences(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Reformat all reschedule requests endpoints

- /api/reschedule/check
  - checks if a meeting can be rescheduled and if the meeting is more important
- /api/reschedule/request
  - Gets a list of all the users requests
- /api/reschedule/request/{requestID}
  - Get a specific request
- /api/reschedule/request/{requestID}/reject
  - reject a request
- /api/reschedule/request/{requestID}/accept
  - accept a request
- /api/reschedule/request/replace
  - Create a rescheduling request for a new meeting
- /api/reschedule/request/single
  - Create a simple rescheduling request